### PR TITLE
Include functionality to add table buttons

### DIFF
--- a/docs/table-models.md
+++ b/docs/table-models.md
@@ -209,6 +209,33 @@ public function query($query)
     return $query->where('name', 'Like', "%John Doe%")->with('roles', 'permissions');
 }
 ```
+### Buttons
+You can specify Table based buttons for available options view Datatables https://datatables.net/reference/button/
+Note: you must use php array not JSON for example
+```public $buttons =  [
+        [
+            'extend' =>  'print',
+            'text'=> 'Print',
+            'exportOptions'=> [
+                'columns'=> [0, ':visible'],
+            ], 
+        ],
+        [
+            'extend' => 'csv',
+            'text'=> 'Excel',
+            'exportOptions'=> [
+                'columns'=> [0, '=>visible'],
+            ],            
+            'filename'=> 'CustomFileName',
+        ],
+        'copy',
+        [
+            'extend'=> 'colvis',
+            'className'=> 'btn btn-dark'
+        ]
+    ];
+```
+
 
 ### Table triggers
 The table triggers an event everytime something is processed. Below is a list of triggers available

--- a/src/resources/views/scripts.blade.php
+++ b/src/resources/views/scripts.blade.php
@@ -237,6 +237,10 @@ $locale = __("datatables") === 'datatables' ? __("datatables::datatables") : __(
                     $(row).on('click', (el) => {
                         $(`#{{ $view->tableId }}`).trigger(`dtrow:click`, [row, data, this.table, el]);
                     });
+                    
+                    $(row).on('dblclick', (el) => {
+                        $(`#{{ $view->tableId }}`).trigger(`dtrow:dblclick`, [row, data, this.table, el]);
+                    });
 
                     $(row).on('mouseenter', (el) => {
                         $(`#{{ $view->tableId }}`).trigger(`dtrow:mouseenter`, [row, data, this.table, el]);

--- a/src/resources/views/scripts.blade.php
+++ b/src/resources/views/scripts.blade.php
@@ -250,7 +250,7 @@ $locale = __("datatables") === 'datatables' ? __("datatables::datatables") : __(
                 order: view.order,
                 columns: view.columns,
                 columnDefs: this.buildColumnDefs(view.defs),
-                buttons: view.buttons,
+                buttons: {!! json_encode($view->buttons()) ?? [] !!},
                 createdRow: (row, data, index) => {
 
                     $(row).on('click', (el) => {

--- a/src/resources/views/scripts.blade.php
+++ b/src/resources/views/scripts.blade.php
@@ -232,6 +232,7 @@ $locale = __("datatables") === 'datatables' ? __("datatables::datatables") : __(
                 order: view.order,
                 columns: view.columns,
                 columnDefs: this.buildColumnDefs(view.defs),
+                buttons: view.buttons,
                 createdRow: (row, data, index) => {
 
                     $(row).on('click', (el) => {


### PR DESCRIPTION
Adds ability for users to include table buttons on the model Fixes #46 
more info about buttons options can be found here https://datatables.net/reference/button/